### PR TITLE
Enforce primary keys on tables that don't have them.

### DIFF
--- a/db_migration/migrate.sql
+++ b/db_migration/migrate.sql
@@ -8,11 +8,69 @@ DROP TABLE nodes_sidecar;
 
 DROP TABLE points_summary;
 
+--bot_logs:
+
 DELETE FROM bot_logs
 WHERE batch_start_epoch <= trunc(extract(epoch from ('2023-12-01 00:00:00+00' :: timestamp)));
 
+-- We need this column to somehow distinguish between identical
+-- rows and drop some so that only a single copy of each remains.
+-- Thankfully, all records with the same id are identical, so
+-- we can just look at id when removing duplicates.
+-- Finally we put PRIMARY KEY constraint on id column so that this
+-- situation does not arise again.
+ALTER TABLE bot_logs
+ADD COLUMN temp_id SERIAL PRIMARY KEY;
+
+DELETE FROM bot_logs AS bl
+USING bot_logs AS helper
+WHERE bl.id = helper.id
+AND bl.temp_id > helper.temp_id;
+
+ALTER TABLE bot_logs
+DROP COLUMN temp_id;
+
+ALTER TABLE bot_logs
+DROP COLUMN status;
+
+ALTER TABLE bot_logs
+DROP COLUMN number_of_threads;
+
+ALTER TABLE bot_logs
+ADD PRIMARY KEY (id);
+
+--nodes:
+
 DELETE FROM nodes
 WHERE updated_at IS NULL;
+
+-- We need this column to somehow distinguish between identical
+-- rows and drop some so that only a single copy of each remains.
+-- Thankfully, all records with the same id are identical, so
+-- we can just look at id when removing duplicates.
+-- Finally we put PRIMARY KEY constraint on id column so that this
+-- situation does not arise again.
+ALTER TABLE nodes
+ADD COLUMN temp_id SERIAL PRIMARY KEY;
+
+DELETE FROM nodes AS n
+USING nodes AS helper
+WHERE n.id = helper.id
+AND n.temp_id > helper.temp_id;
+
+ALTER TABLE nodes
+DROP COLUMN temp_id;
+
+ALTER TABLE nodes
+ALTER COLUMN updated_at SET NOT NULL;
+
+ALTER TABLE nodes
+ALTER COLUMN score_percent TYPE NUMERIC(10, 2);
+
+ALTER TABLE nodes
+ADD PRIMARY KEY (id);
+
+-- points:
 
 DELETE FROM points
 WHERE bot_log_id IS NULL
@@ -21,35 +79,43 @@ OR statehash_id IS NULL
 OR bot_log_id NOT IN (SELECT id FROM bot_logs)
 OR node_id NOT IN (SELECT id FROM nodes);
 
+ALTER TABLE points
+ALTER COLUMN node_id SET NOT NULL;
+
+ALTER TABLE points
+ALTER COLUMN bot_log_id SET NOT NULL;
+
+ALTER TABLE points
+ADD FOREIGN KEY (bot_log_id) REFERENCES bot_logs(id);
+
+ALTER TABLE points
+ADD FOREIGN KEY (node_id) REFERENCES nodes(id);
+
+DROP TRIGGER trg_update_point_summary ON points;
+
+-- bot_logs_statehash:
+
 DELETE FROM bot_logs_statehash
 WHERE bot_log_id IS NULL
 OR statehash_id IS NULL
 OR bot_log_id NOT IN (SELECT id FROM bot_logs);
 
-DELETE FROM score_history
-WHERE node_id IS NULL
-OR node_id NOT IN (SELECT id FROM nodes);
+-- We need this column to somehow distinguish between identical
+-- rows and drop some so that only a single copy of each remains.
+-- Thankfully, all records with the same id are identical, so
+-- we can just look at id when removing duplicates.
+-- Finally we put PRIMARY KEY constraint on id column so that this
+-- situation does not arise again.
+ALTER TABLE bot_logs_statehash
+ADD COLUMN temp_id SERIAL PRIMARY KEY;
 
-DELETE FROM statehash
-WHERE id NOT IN (
-  SELECT DISTINCT statehash_id
-  FROM bot_logs_statehash
-  WHERE statehash_id IS NOT NULL
-  UNION
-  SELECT DISTINCT parent_statehash_id
-  FROM bot_logs_statehash
-  WHERE parent_statehash_id IS NOT NULL
-  UNION
-  SELECT DISTINCT statehash_id
-  FROM points
-  WHERE statehash_id IS NOT NULL
-);
+DELETE FROM bot_logs_statehash AS bls
+USING bot_logs_statehash AS helper
+WHERE bls.id = helper.id
+AND bls.temp_id > helper.temp_id;
 
-ALTER TABLE bot_logs
-DROP COLUMN status;
-
-ALTER TABLE bot_logs
-DROP COLUMN number_of_threads;
+ALTER TABLE bot_logs_statehash
+DROP COLUMN temp_id;
 
 ALTER TABLE bot_logs_statehash
 ALTER COLUMN  statehash_id SET NOT NULL;
@@ -69,17 +135,14 @@ ADD FOREIGN KEY (statehash_id) REFERENCES statehash(id);
 ALTER TABLE bot_logs_statehash
 ADD FOREIGN KEY (parent_statehash_id) REFERENCES statehash(id);
 
-ALTER TABLE points
-ALTER COLUMN node_id SET NOT NULL;
+ALTER TABLE bot_logs_statehash
+ADD PRIMARY KEY (id);
 
-ALTER TABLE points
-ALTER COLUMN bot_log_id SET NOT NULL;
+-- score_history:
 
-ALTER TABLE points
-ADD FOREIGN KEY (bot_log_id) REFERENCES bot_logs(id);
-
-ALTER TABLE points
-ADD FOREIGN KEY (node_id) REFERENCES nodes(id);
+DELETE FROM score_history
+WHERE node_id IS NULL
+OR node_id NOT IN (SELECT id FROM nodes);
 
 ALTER TABLE score_history
 ALTER COLUMN node_id SET NOT NULL;
@@ -93,12 +156,21 @@ ADD COLUMN id SERIAL PRIMARY KEY;
 ALTER TABLE score_history
 ALTER COLUMN score_percent TYPE NUMERIC(10, 2);
 
-ALTER TABLE nodes
-ALTER COLUMN updated_at SET NOT NULL;
+-- statehash
 
-ALTER TABLE nodess
-ALTER COLUMN score_percent TYPE NUMERIC(10, 2);
-
-DROP TRIGGER trg_update_point_summary ON points;
+DELETE FROM statehash
+WHERE id NOT IN (
+  SELECT DISTINCT statehash_id
+  FROM bot_logs_statehash
+  WHERE statehash_id IS NOT NULL
+  UNION
+  SELECT DISTINCT parent_statehash_id
+  FROM bot_logs_statehash
+  WHERE parent_statehash_id IS NOT NULL
+  UNION
+  SELECT DISTINCT statehash_id
+  FROM points
+  WHERE statehash_id IS NOT NULL
+);
 
 COMMIT;


### PR DESCRIPTION
Some tables don't have primary keys, which allows them to contain sets of identical records. This is not only wasteful, but also obstructs foreign key formalisation. For this reason we clean tables of duplicated rows, enforce primary keys on `id` columns and finally set up foreign keys on dependent tables.

This is respons to problem encountered during script's application on production database.