### PR TITLE
PM-1638 Migration script updates

### DIFF
--- a/db_migration/README.md
+++ b/db_migration/README.md
@@ -18,7 +18,13 @@ NOTE: this will take several hours to execute (a lot of rows to drop and constra
 Under some circumstances (like e.g. an emergency hard fork) there might not be enough time to take a full Ontab database’s snapshot quickly (it takes several hours to produce) and then trim it (which takes another several hours). In that case a quicker approach can be used to synchronise the databases – the script linked below can be used to take a partial db dump (for increased speed) from the original database and move relevant records to the new database. The script can be run like this:
 
 ```bash
-$ python db_diff.py -H $HOST -p $PORT -U $USERNAME -w $PASSWORD -d leaderboard_snark $DATE
+$ python db_diff.py -H $HOST -p $PORT -U $USERNAME -w $PASSWORD -d leaderboard_snark -t all $DATE > dump.sql
+Bot logs fetched: 5932 rows
+Statehash fetched: 57165 rows
+Bot_logs_statehash fetched: 94737 rows
+Nodes fetched: 1495 rows
+Points fetched: 21950363 rows
+Score history fetched: 8584008 rows
 ```
 
 [db_diff.py](./db_diff.py)
@@ -32,5 +38,10 @@ Where:
 - `$DATE` is the day from which we want to take the diff (e.g. 2024-02-01). Only records added after that date will be dumped.
 
 NOTE: the script requires psycopg2 package downloaded from pip.
+You can dump data from all tables (`-t all`) or subset of supported tables (points, score_history, nodes, bot_logs, statehash, bot_logs_statehash), (e.g. `-t points,nodes`) 
 
-This script will produce some SQL commands on the standard output. Write it to a file and run the script against the target database in order to load the data. Or you can simply pipe it to the `psql` command.
+This script will produce some SQL commands on the standard output and log some information to the standard error. Write it to a file and run the script against the target database in order to load the data. For instance, assuming the target database `delegation_program` is on localhost:
+
+```bash
+psql -h localhost -p 5432 -U postgres -d delegation_program -f dump.sql
+```

--- a/db_migration/db_diff.py
+++ b/db_migration/db_diff.py
@@ -1,5 +1,5 @@
 import argparse
-from datetime import datetime
+from datetime import datetime, timedelta
 import psycopg2
 from psycopg2.sql import Literal
 
@@ -126,7 +126,9 @@ def main(args):
     statehash = Insert(conn, "statehash", ("id", "value"))
     statehash.fetch(
         "bl.batch_end_epoch >= trunc(extract(epoch from (%s)))",
-        (args.last_update,),
+        # We need to fetch the last statehash before the range (which is needed for the parent_statehash_id column)
+        # so let's fetch last_update - 60 minutes
+        (args.last_update - timedelta(minutes=60),),
         joins=(
             {
                 "tbl": "bot_logs_statehash",

--- a/db_migration/db_diff.py
+++ b/db_migration/db_diff.py
@@ -1,5 +1,6 @@
 import argparse
 from datetime import datetime, timedelta
+import sys
 import psycopg2
 from psycopg2.sql import Literal
 
@@ -122,6 +123,10 @@ def main(args):
         (args.last_update,),
     )
     bot_logs.print()
+    print(
+        "Bot logs fetched: {} rows".format(len(bot_logs.results)),
+        file=sys.stderr,
+    )
 
     statehash = Insert(conn, "statehash", ("id", "value"))
     statehash.fetch(
@@ -140,6 +145,10 @@ def main(args):
         ),
     )
     statehash.print()
+    print(
+        "Statehash fetched: {} rows".format(len(statehash.results)),
+        file=sys.stderr,
+    )
 
     bot_logs_statehash = Insert(
         conn,
@@ -159,6 +168,10 @@ def main(args):
         ),
     )
     bot_logs_statehash.print()
+    print(
+        "Bot_logs_statehash fetched: {} rows".format(len(bot_logs_statehash.results)),
+        file=sys.stderr,
+    )
 
     nodes = Insert(
         conn,
@@ -175,6 +188,10 @@ def main(args):
     )
     nodes.fetch_all()
     nodes.print()
+    print(
+        "Nodes fetched: {} rows".format(len(nodes.results)),
+        file=sys.stderr,
+    )
 
     points = Insert(
         conn,
@@ -200,12 +217,20 @@ def main(args):
         ),
     )
     points.print()
+    print(
+        "Points fetched: {} rows".format(len(points.results)),
+        file=sys.stderr,
+    )
 
     score_history = Insert(
         conn, "score_history", ("node_id", "score_at", "score", "score_percent")
     )
     score_history.fetch("score_at >= %s AND score_at IS NOT NULL", (args.last_update,))
     score_history.print()
+    print(
+        "Score history fetched: {} rows".format(len(score_history.results)),
+        file=sys.stderr,
+    )
 
     print("COMMIT;")
 

--- a/db_migration/db_diff.py
+++ b/db_migration/db_diff.py
@@ -32,7 +32,6 @@ class Insert:
     def fetch_all(self):
         with self.connection.cursor() as cursor:
             q = "SELECT {} FROM {}".format(", ".join(self.columns), self.table)
-            # print("Executing query:", q)
             cursor.execute(q)
             self.results = cursor.fetchall()
 
@@ -49,23 +48,6 @@ class Insert:
         q = "SELECT DISTINCT {} FROM {} {} WHERE {} ORDER BY {}.{} {} LIMIT {}".format(
             cols, self.table, j, condition, self.table, self.columns[0], order_by, limit
         )
-
-        # Print the query template with placeholders
-        print("Executing query template:", q)
-        print("With arguments:", args)
-
-        # Replace placeholders with actual argument values for debugging
-        query_with_args = q
-        for arg in args:
-            if isinstance(arg, str):
-                arg = "'{}'".format(
-                    arg.replace("'", "''")
-                )  # Escape single quotes in strings
-            elif arg is None:
-                arg = "NULL"
-            query_with_args = query_with_args.replace("%s", str(arg), 1)
-
-        print("Full query with arguments:", query_with_args)
 
         with self.connection.cursor() as cursor:
             cursor.execute(q, args)

--- a/db_migration/db_diff.py
+++ b/db_migration/db_diff.py
@@ -122,19 +122,6 @@ def main(args):
             {"tbl": "bot_logs", "as": "bl", "col": "id", "val": "bls.bot_log_id"},
         ),
     )
-    statehash.fetch(
-        "bl.batch_end_epoch >= trunc(extract(epoch from (%s)))",
-        (args.last_update,),
-        joins=(
-            {
-                "tbl": "bot_logs_statehash",
-                "as": "bls",
-                "col": "parent_statehash_id",
-                "val": "statehash.id",
-            },
-            {"tbl": "bot_logs", "as": "bl", "col": "id", "val": "bls.bot_log_id"},
-        ),
-    )
     statehash.print()
 
     bot_logs_statehash = Insert(

--- a/db_migration/db_diff.py
+++ b/db_migration/db_diff.py
@@ -19,6 +19,7 @@ def batched(iterable, n):
     if items:
         yield items
 
+
 class Insert:
 
     def __init__(self, connection, table, columns):
@@ -28,35 +29,56 @@ class Insert:
         self.results = []
 
     def fetch(self, condition, args, joins=()):
-        cols = ', '.join('{}.{}'.format(self.table, col) for col in self.columns)
-        j = ' '.join('JOIN {tbl} AS {as} ON {as}.{col} = {val}'.format(**join) for join in joins)
-        q = 'SELECT DISTINCT {} FROM {} {} WHERE {} ORDER BY {}.{} LIMIT ALL'
+        cols = ", ".join("{}.{}".format(self.table, col) for col in self.columns)
+        j = " ".join(
+            "JOIN {tbl} AS {as} ON {as}.{col} = {val}".format(**join) for join in joins
+        )
+        q = "SELECT DISTINCT {} FROM {} {} WHERE {} ORDER BY {}.{} LIMIT ALL"
         with self.connection.cursor() as cursor:
-            cursor.execute(q.format(cols, self.table, j, condition, self.table, self.columns[0]), args)
+            cursor.execute(
+                q.format(cols, self.table, j, condition, self.table, self.columns[0]),
+                args,
+            )
             self.results += cursor.fetchall()
 
     def print(self):
         for batch in batched(self.results, 1000):
-            cols = ', '.join(self.columns)
-            print('INSERT INTO {}'.format(self.table))
-            print('    ({})'.format(cols))
-            print('VALUES')
-            print('   ', ',\n    '.join('({})'.format(', '.join(Literal(item).as_string(self.connection) for item in row)) for row in batch))
-            print('ON CONFLICT(id)')
-            print('DO UPDATE SET')
-            print('   ', ',\n    '.join('{col} = EXCLUDED.{col}'.format(col=col) for col in self.columns))
-            print(';')
+            cols = ", ".join(self.columns)
+            print("INSERT INTO {}".format(self.table))
+            print("    ({})".format(cols))
+            print("VALUES")
+            print(
+                "   ",
+                ",\n    ".join(
+                    "({})".format(
+                        ", ".join(
+                            Literal(item).as_string(self.connection) for item in row
+                        )
+                    )
+                    for row in batch
+                ),
+            )
+            print("ON CONFLICT(id)")
+            print("DO UPDATE SET")
+            print(
+                "   ",
+                ",\n    ".join(
+                    "{col} = EXCLUDED.{col}".format(col=col) for col in self.columns
+                ),
+            )
+            print(";")
 
 
 def parse_args():
-    p = argparse.ArgumentParser(description='Diff two uptime service databases.')
-    p.add_argument('-H', '--host', help='Database hostname', default='localhost')
-    p.add_argument('-p', '--port', help='Database port', default=5432, type=int)
-    p.add_argument('-U', '--user', help='Database username', default='postgres')
-    p.add_argument('-w', '--password', help='Database password', required=True)
-    p.add_argument('-d', '--database', help='Database name', required=True)
-    p.add_argument('last_update', help='Last update time', type=datetime.fromisoformat)
+    p = argparse.ArgumentParser(description="Diff two uptime service databases.")
+    p.add_argument("-H", "--host", help="Database hostname", default="localhost")
+    p.add_argument("-p", "--port", help="Database port", default=5432, type=int)
+    p.add_argument("-U", "--user", help="Database username", default="postgres")
+    p.add_argument("-w", "--password", help="Database password", required=True)
+    p.add_argument("-d", "--database", help="Database name", required=True)
+    p.add_argument("last_update", help="Last update time", type=datetime.fromisoformat)
     return p.parse_args()
+
 
 def main(args):
     conn = psycopg2.connect(
@@ -64,114 +86,137 @@ def main(args):
         password=args.password,
         host=args.host,
         port=args.port,
-        database=args.database
+        database=args.database,
     )
 
-    print('BEGIN;\n')
+    print("BEGIN;\n")
     bot_logs = Insert(
         conn,
-        'bot_logs',
-        ('id',
-         'files_processed',
-         'file_timestamps',
-         'batch_start_epoch',
-         'batch_end_epoch',
-         'processing_time')
+        "bot_logs",
+        (
+            "id",
+            "files_processed",
+            "file_timestamps",
+            "batch_start_epoch",
+            "batch_end_epoch",
+            "processing_time",
+        ),
     )
     bot_logs.fetch(
-        'bot_logs.batch_end_epoch >= trunc(extract(epoch from (%s)))',
-        (args.last_update, )
+        "bot_logs.batch_end_epoch >= trunc(extract(epoch from (%s)))",
+        (args.last_update,),
     )
     bot_logs.print()
 
-    statehash = Insert(conn, 'statehash', ('id', 'value'))
+    statehash = Insert(conn, "statehash", ("id", "value"))
     statehash.fetch(
-        'bl.batch_end_epoch >= trunc(extract(epoch from (%s)))',
-        (args.last_update, ),
-        joins=({'tbl': 'bot_logs_statehash', 'as': 'bls', 'col': 'statehash_id', 'val': 'statehash.id'},
-               {'tbl': 'bot_logs', 'as': 'bl', 'col': 'id', 'val': 'bls.bot_log_id'})
+        "bl.batch_end_epoch >= trunc(extract(epoch from (%s)))",
+        (args.last_update,),
+        joins=(
+            {
+                "tbl": "bot_logs_statehash",
+                "as": "bls",
+                "col": "statehash_id",
+                "val": "statehash.id",
+            },
+            {"tbl": "bot_logs", "as": "bl", "col": "id", "val": "bls.bot_log_id"},
+        ),
     )
     statehash.fetch(
-        'bl.batch_end_epoch >= trunc(extract(epoch from (%s)))',
-        (args.last_update, ),
-        joins=({'tbl': 'bot_logs_statehash', 'as': 'bls', 'col': 'parent_statehash_id', 'val': 'statehash.id'},
-               {'tbl': 'bot_logs', 'as': 'bl', 'col': 'id', 'val': 'bls.bot_log_id'})
+        "bl.batch_end_epoch >= trunc(extract(epoch from (%s)))",
+        (args.last_update,),
+        joins=(
+            {
+                "tbl": "bot_logs_statehash",
+                "as": "bls",
+                "col": "parent_statehash_id",
+                "val": "statehash.id",
+            },
+            {"tbl": "bot_logs", "as": "bl", "col": "id", "val": "bls.bot_log_id"},
+        ),
     )
     statehash.print()
 
     bot_logs_statehash = Insert(
         conn,
-        'bot_logs_statehash',
-        ('id',
-         'bot_log_id',
-         'statehash_id',
-         'parent_statehash_id',
-         'weight')
+        "bot_logs_statehash",
+        ("id", "bot_log_id", "statehash_id", "parent_statehash_id", "weight"),
     )
     bot_logs_statehash.fetch(
-        'bl.batch_end_epoch >= trunc(extract(epoch from (%s)))',
-        (args.last_update, ),
-        joins=({'tbl': 'bot_logs', 'as': 'bl', 'col': 'id', 'val': 'bot_logs_statehash.bot_log_id'}, )
+        "bl.batch_end_epoch >= trunc(extract(epoch from (%s)))",
+        (args.last_update,),
+        joins=(
+            {
+                "tbl": "bot_logs",
+                "as": "bl",
+                "col": "id",
+                "val": "bot_logs_statehash.bot_log_id",
+            },
+        ),
     )
     bot_logs_statehash.print()
 
     nodes = Insert(
         conn,
-        'nodes',
-        ('id',
-         'block_producer_key',
-         'score',
-         'score_percent',
-         'updated_at',
-         'email_id',
-         'application_status')
+        "nodes",
+        (
+            "id",
+            "block_producer_key",
+            "score",
+            "score_percent",
+            "updated_at",
+            "email_id",
+            "application_status",
+        ),
     )
     nodes.fetch(
-        'bl.batch_end_epoch >= trunc(extract(epoch from (%s))) AND updated_at IS NOT NULL',
-        (args.last_update, ),
-        joins=({'tbl': 'points', 'as': 'p', 'col': 'node_id', 'val': 'nodes.id'},
-               {'tbl': 'bot_logs', 'as': 'bl', 'col': 'id', 'val': 'p.bot_log_id'})
+        "bl.batch_end_epoch >= trunc(extract(epoch from (%s))) AND updated_at IS NOT NULL",
+        (args.last_update,),
+        joins=(
+            {"tbl": "points", "as": "p", "col": "node_id", "val": "nodes.id"},
+            {"tbl": "bot_logs", "as": "bl", "col": "id", "val": "p.bot_log_id"},
+        ),
     )
     for row in nodes.results:
         if row[4] is None:
             # we don't want NULLs in this column, so we have to insert something
             # it doesn't really matter much anyways.
-            row[4] = 'now()'
+            row[4] = "now()"
     nodes.print()
 
     points = Insert(
         conn,
-        'points',
-        ('id',
-         'file_name',
-         'blockchain_epoch',
-         'blockchain_height',
-         'created_at',
-         'amount',
-         'node_id',
-         'bot_log_id',
-         'file_timestamps',
-         'statehash_id')
+        "points",
+        (
+            "id",
+            "file_name",
+            "blockchain_epoch",
+            "blockchain_height",
+            "created_at",
+            "amount",
+            "node_id",
+            "bot_log_id",
+            "file_timestamps",
+            "statehash_id",
+        ),
     )
     points.fetch(
-        'bl.batch_end_epoch >= trunc(extract(epoch from (%s)))',
-        (args.last_update, ),
-        joins=({'tbl': 'bot_logs', 'as': 'bl', 'col': 'id', 'val': 'points.bot_log_id'}, )
+        "bl.batch_end_epoch >= trunc(extract(epoch from (%s)))",
+        (args.last_update,),
+        joins=(
+            {"tbl": "bot_logs", "as": "bl", "col": "id", "val": "points.bot_log_id"},
+        ),
     )
     points.print()
 
     score_history = Insert(
-        conn,
-        'score_history',
-        ('node_id',
-         'score_at',
-         'score',
-         'score_percent')
+        conn, "score_history", ("node_id", "score_at", "score", "score_percent")
     )
-    score_history.fetch('score_at >= %s AND score_at IS NOT NULL', (args.last_update, ))
+    score_history.fetch("score_at >= %s AND score_at IS NOT NULL", (args.last_update,))
     score_history.print()
 
-    print('COMMIT;')
+    print("COMMIT;")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main(parse_args())

--- a/db_migration/migrate.sql
+++ b/db_migration/migrate.sql
@@ -111,4 +111,33 @@ WHERE id NOT IN (
   WHERE statehash_id IS NOT NULL
 );
 
+-- Table submission is used to store the submissions made by each submitter.
+CREATE TABLE IF NOT EXISTS submissions (
+	-- filled by uptime_service_backend
+    id SERIAL PRIMARY KEY,
+    submitted_at_date DATE NOT NULL,
+    submitted_at TIMESTAMP NOT NULL,
+    submitter TEXT NOT NULL,
+    created_at TIMESTAMP,
+    block_hash TEXT,
+    remote_addr TEXT,
+    peer_id TEXT,
+    snark_work BYTEA,
+    graphql_control_port INT,
+    built_with_commit_sha TEXT,
+	-- filled by zk-validator component
+    state_hash TEXT,
+    parent TEXT,
+    height INTEGER,
+    slot INTEGER,
+    validation_error TEXT,
+    verified BOOLEAN
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_submissions_submitter_date ON submissions USING btree (submitter, submitted_at);
+
+-- Additional indexes for better query performance
+CREATE INDEX IF NOT EXISTS idx_submissions_submitter_date ON submissions (submitter, submitted_at_date);
+CREATE INDEX IF NOT EXISTS idx_submissions_submitter_datetime ON submissions (submitter, submitted_at DESC);
+
+
 COMMIT;

--- a/db_migration/migrate.sql
+++ b/db_migration/migrate.sql
@@ -6,8 +6,6 @@ DROP TABLE bp_ip_address_2022_12;
 
 DROP TABLE nodes_sidecar;
 
-DROP TABLE points_summary;
-
 --bot_logs:
 
 DELETE FROM bot_logs

--- a/db_migration/migrate.sql
+++ b/db_migration/migrate.sql
@@ -26,7 +26,7 @@ ALTER TABLE nodes
 ALTER COLUMN updated_at SET NOT NULL;
 
 ALTER TABLE nodes
-ALTER COLUMN score_percent TYPE NUMERIC(10, 2);
+ALTER COLUMN score_percent TYPE NUMERIC(5, 2);
 
 -- points:
 
@@ -92,7 +92,7 @@ ALTER TABLE score_history
 ADD COLUMN id SERIAL PRIMARY KEY;
 
 ALTER TABLE score_history
-ALTER COLUMN score_percent TYPE NUMERIC(10, 2);
+ALTER COLUMN score_percent TYPE NUMERIC(5, 2);
 
 -- statehash
 


### PR DESCRIPTION
This pr updates `migrate.sql` and `db_diff.py` scripts such that they are up-to-date with the recent coordinator schema changes. Additionally there were some changes done in `db_diff.py`, the script was tested on ontab mainnet db and produced sql successfuly imported to new schema.
Some changes include:
 - fixed `statehash.fetch` done twice
 - fetch all nodes (they are not so many in DB currently (1495), and getting only the subset was failing for some reason on importing the data)
 - some logging added on stderr, logging how many rows imported on each table
 - add `--tables` parameter such that we can dump all tables, or just a subset (may be useful in case there is some interruption during the script run) 