### PR TITLE
PM-1638 no timeouts on executing query

### DIFF
--- a/db_migration/db_diff.py
+++ b/db_migration/db_diff.py
@@ -139,21 +139,7 @@ def main(args):
 
     if "all" in tables or "statehash" in tables:
         statehash = Insert(conn, "statehash", ("id", "value"))
-        statehash.fetch(
-            "bl.batch_end_epoch >= trunc(extract(epoch from (%s)))",
-            # We need to fetch the last statehash before the range (which is needed for the parent_statehash_id column)
-            # so let's fetch last_update - 60 minutes
-            (args.last_update - timedelta(minutes=60),),
-            joins=(
-                {
-                    "tbl": "bot_logs_statehash",
-                    "as": "bls",
-                    "col": "statehash_id",
-                    "val": "statehash.id",
-                },
-                {"tbl": "bot_logs", "as": "bl", "col": "id", "val": "bls.bot_log_id"},
-            ),
-        )
+        statehash.fetch_all()
         statehash.print()
         print(
             "Statehash fetched: {} rows".format(len(statehash.results)),

--- a/db_migration/db_diff.py
+++ b/db_migration/db_diff.py
@@ -50,6 +50,9 @@ class Insert:
         )
 
         with self.connection.cursor() as cursor:
+            # No timeout
+            cursor.execute("SET statement_timeout = '0';")
+            cursor.execute("SET idle_in_transaction_session_timeout = '0';")
             cursor.execute(q, args)
             self.results += cursor.fetchall()
 


### PR DESCRIPTION
During the testing we see that sometimes scripts fails on timeouts, because the queries take quite a long time:

```
Traceback (most recent call last):
  File "/mina-delegation-program-tech/db_migration/db_diff.py", line 259, in <module>
    main(parse_args())
  File "/mina-delegation-program-tech/db_migration/db_diff.py", line 246, in main
    score_history.fetch(
  File "/mina-delegation-program-tech/db_migration/db_diff.py", line 53, in fetch
    cursor.execute(q, args)
psycopg2.OperationalError: SSL connection has been closed unexpectedly
```
This should cover this issue. After this change I'm able to achieve clean run:
```
$ time python db_diff.py -H $HOST -p $PORT -U $USERNAME -w $PASSWORD -d leaderboard_snark --tables all 2024-02-25 > 2024-02-25.sql
Bot logs fetched: 6156 rows
Statehash fetched: 59067 rows
Bot_logs_statehash fetched: 97615 rows
Nodes fetched: 1495 rows
Points fetched: 22793613 rows
Score history fetched: 8914122 rows

real	39m52,077s
user	7m38,616s
sys	0m27,653s

```